### PR TITLE
Change fb_isVisible implementation for Xcode 9 / iOS 11

### DIFF
--- a/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
+++ b/WebDriverAgentLib/Categories/XCUIElement+FBIsVisible.m
@@ -48,7 +48,15 @@
   if (!CGRectIntersectsRect(visibleFrame, screenFrame)) {
     return NO;
   }
-  return CGRectContainsPoint(appFrame, self.fb_hitPoint);
+  if (CGRectContainsPoint(appFrame, self.fb_hitPoint)) {
+    return YES;
+  }
+  for (XCElementSnapshot *elementSnapshot in self._allDescendants.copy) {
+    if (CGRectContainsPoint(appFrame, elementSnapshot.fb_hitPoint)) {
+      return YES;
+    }
+  }
+  return NO;
 }
 
 @end


### PR DESCRIPTION
Summary: fb_isVisible implementation is changed and it's more aggressive in marking elements as not visible.

Reviewed By: lawrencelomax

Differential Revision: D5745747

fbshipit-source-id: 10194e12869878e4940d72007c728886376b54ec