### PR TITLE
Don't check if element is obstructed by alert while fetching.

### DIFF
--- a/WebDriverAgentLib/Routing/FBElementCache.m
+++ b/WebDriverAgentLib/Routing/FBElementCache.m
@@ -44,9 +44,6 @@
   }
   XCUIElement *element = self.elementCache[uuid];
   [element resolve];
-  if (element.fb_isObstructedByAlert) {
-    [FBAlert throwRequestedItemObstructedByAlertException];
-  }
   return element;
 }
 

--- a/WebDriverAgentTests/UnitTests/FBElementCacheTests.m
+++ b/WebDriverAgentTests/UnitTests/FBElementCacheTests.m
@@ -53,12 +53,4 @@
   XCTAssertTrue(element.didResolve);
 }
 
-- (void)testAlertObstructionCheckWhenFetchingElement
-{
-  XCUIElementDouble *elementDouble = XCUIElementDouble.new;
-  elementDouble.fb_isObstructedByAlert = YES;
-  NSString *uuid = [self.cache storeElement:(XCUIElement *)elementDouble];
-  XCTAssertThrows([self.cache elementForUUID:uuid]);
-}
-
 @end


### PR DESCRIPTION
Summary: This causes us to query for the alert, which goes through looking for sheets in springboard. That takes roughly 0.05 seconds each time and makes execution really slow for complicated actions. Note this is a behavioural change in the case element is actually obstructed, so the error might message for that might move somewhere else in the stack.

Reviewed By: lawrencelomax

Differential Revision: D5823287

fbshipit-source-id: 60c7adb6ef4a786d92bc95746784b06283bcf3d2