### PR TITLE
Compute first value only once.

### DIFF
--- a/WebDriverAgentLib/Utilities/FBMacros.h
+++ b/WebDriverAgentLib/Utilities/FBMacros.h
@@ -18,7 +18,10 @@
 #define FBTransferEmptyStringToNil(value) ([value isEqual:@""] ? nil : value)
 
 /*! Returns 'value1' or 'value2' if 'value1' is an empty string */
-#define FBFirstNonEmptyValue(value1, value2) (value1 == nil || [value1 isEqual:@""] ? value2 : value1)
+#define FBFirstNonEmptyValue(value1, value2) ^{ \
+  id value1computed = value1; \
+  return (value1computed == nil || [value1computed isEqual:@""] ? value2 : value1computed); \
+}()
 
 /*! Returns 'value' or NSNull if 'value' is nil */
 #define FBValueOrNull(value) ((value) ?: [NSNull null])


### PR DESCRIPTION
Summary:
value1 can be an expression which is expensive. :)

Initially:

{P58681884}

Now:

{P58681886}

We're computing one time instead of thrice, therefore ~0.1 instead of 0.3. :)

Reviewed By: marekcirkos

Differential Revision: D6416011

fbshipit-source-id: 4b36bdaf205548e530cc099f0d853e7f7f392ab7