### PR TITLE
Fix tapXY coordinates for non fullscreen windows

### DIFF
--- a/WebDriverAgentLib/Commands/FBElementCommands.m
+++ b/WebDriverAgentLib/Commands/FBElementCommands.m
@@ -512,7 +512,11 @@ static const CGFloat DEFAULT_OFFSET = (CGFloat)0.2;
   XCUIElement *element = application;
   if (isSDKVersionGreaterThanOrEqualTo(@"11.0")) {
     XCUIElement *window = application.windows.fb_firstMatch;
-    if (window) element = window;
+    if (window) {
+      element = window;
+      point.x -= element.frame.origin.x;
+      point.y -= element.frame.origin.y;
+    }
   }
   return [self gestureCoordinateWithCoordinate:point element:element];
 }


### PR DESCRIPTION
Summary:
D7947931 patches taping XY for rotated screens however it does not work in case window does not cover fullscreen.
In such case we need patch coordinates to take into account window's offset to correctly calculate final XY tap coordinates

Reviewed By: antiarchit

Differential Revision: D8820400

fbshipit-source-id: 3c526253d86b680a37fb55c25d237e4a9de459a2